### PR TITLE
Adiciona link para o playground

### DIFF
--- a/modules/instalando.md
+++ b/modules/instalando.md
@@ -4,10 +4,16 @@
 
 ## Índice
 
+- [Playground](./instalando.md#playgroud)
+
 - [Requisitos](./instalando.md#requisitos)
 
 - [Downloads](./instalando.md#downloads)
 
+## Playground
+
+A [golang.org](https://play.golang.org) criou um serviço web chamado [playground](https://play.golang.org/) que compila, executa e mostra o output do código escrito pelo usuário. 
+É um serviço útil para poder testar a linguagem sem ter a necessidade de fazer a instalação.
 ## Requisitos
 
 As distribuições binárias Go estão disponíveis para esses sistemas operacionais e arquiteturas suportados. Verifique se o seu sistema atende a esses requisitos antes de continuar. Se o seu sistema operacional ou arquitetura não estiver na lista, você poderá instalar a partir da fonte ou usar o gccgo.

--- a/modules/instalando.md
+++ b/modules/instalando.md
@@ -4,7 +4,7 @@
 
 ## Índice
 
-- [Playground](./instalando.md#playgroud)
+- [Playground](./instalando.md#playground)
 
 - [Requisitos](./instalando.md#requisitos)
 

--- a/modules/instalando.md
+++ b/modules/instalando.md
@@ -13,7 +13,7 @@
 ## Playground
 
 A [golang.org](https://play.golang.org) criou um serviço web chamado [playground](https://play.golang.org/) que compila, executa e mostra o output do código escrito pelo usuário. 
-É um serviço útil para poder testar a linguagem sem ter a necessidade de fazer a instalação.
+É um serviço útil para poder testar a linguagem sem ter a necessidade de fazer a instalação e até mesmo para compartilhar código.
 ## Requisitos
 
 As distribuições binárias Go estão disponíveis para esses sistemas operacionais e arquiteturas suportados. Verifique se o seu sistema atende a esses requisitos antes de continuar. Se o seu sistema operacional ou arquitetura não estiver na lista, você poderá instalar a partir da fonte ou usar o gccgo.


### PR DESCRIPTION
Adiciono link do playground da Go, que serve para poder ter um primeiro contato sem a barreira de ter que fazer a instalação.